### PR TITLE
set to show line number by default

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,3 +1,5 @@
+" set number line indication, `set nonu` to disable it
+set nu
 set term=xterm-256color
 " Use smartindent
 set smartindent


### PR DESCRIPTION
It looks good.

I don't know what the point it is, that `github` has `GPG` commit verification. To show somebody that the codes are committed and transported securely? :dog2: 

This is very useful for those private repos. But for public repo, this is somehow a showoff. :smiling_imp: 