### PR TITLE
Add support for Ubuntu 16.04 and add pre-compiled Vim 7.4 with `Python` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Usage
 
 Explanation
 ----
-* This is very neat for new PC initialization. Mostly for Debian/Ubuntu or its derived destros. This is friendly compaitble with Ubuntu12.04+/Linuxmint13+/Debian6+ and more their derived destros.
+* This is very neat for new PC initialization. Mostly for Debian/Ubuntu or its derived destros. This is friendly compaitble with Ubuntu12.04+/Linuxmint13+/Debian6+/Ubuntu14.04/Ubuntu16.04 and more their derived destros.
 
 * Notice that: For some vim users to use tagbar/ctags, they would need to install the package "ctags". For example on debian/ubuntu ```sudo apt-get install ctags``` , or on centOS/Fedora/RHEL ```sudo yum install ctags```, or on archlinux ```pacman -S ctags```
 * The ```init_*.sh``` and the ```cp_files.sh``` are very neat for new users both on ubuntu12.04 and ubuntu14.04.
-```init_ubuntu_12.04.sh``` is compatible with Debian7/Ubuntu12.04 while ```init_ubuntu_14.04.sh``` is for Ubuntu14.04.
+```init_ubuntu_12.04.sh``` is compatible with Debian7/Ubuntu12.04 while ```init_ubuntu_14.04.sh``` is for Ubuntu14.04. The default Vim provided on Ubuntu 16.04 is not pre-compiled with `Python` support. To use these Vim settings, you should install Vim with Python support. See [here]() for info about compiling it, or [here]() to download a Vim deb package pre-compiled with `Python` support.
 
 #### Python IDE
 * There's a Python IDE inside. Type **:Ide** in the Vim prompt console.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Explanation
 
 * Notice that: For some vim users to use tagbar/ctags, they would need to install the package "ctags". For example on debian/ubuntu ```sudo apt-get install ctags``` , or on centOS/Fedora/RHEL ```sudo yum install ctags```, or on archlinux ```pacman -S ctags```
 * The ```init_*.sh``` and the ```cp_files.sh``` are very neat for new users both on ubuntu12.04 and ubuntu14.04.
-```init_ubuntu_12.04.sh``` is compatible with Debian7/Ubuntu12.04 while ```init_ubuntu_14.04.sh``` is for Ubuntu14.04. The default Vim provided on Ubuntu 16.04 is not pre-compiled with `Python` support. To use these Vim settings, you should install Vim with Python support. See [here]() for info about compiling it, or [here]() to download a Vim deb package pre-compiled with `Python` support.
+```init_ubuntu_12.04.sh``` is compatible with Debian7/Ubuntu12.04 while ```init_ubuntu_14.04.sh``` is for Ubuntu14.04. The default Vim provided on Ubuntu 16.04 is not pre-compiled with `Python` support. To use these Vim settings, you should install Vim with Python support. See [here](https://github.com/Valloric/YouCompleteMe/wiki/Building-Vim-from-source) for info about compiling it, or [here](https://drive.google.com/open?id=0BzL1CwVspEkiS2lwUURsQUMtYUU) to download a Vim deb package pre-compiled with `Python` support.
 
 #### Python IDE
 * There's a Python IDE inside. Type **:Ide** in the Vim prompt console.


### PR DESCRIPTION
Provides methods of compiling and a `deb` package of Vim