### PR TITLE
Update colorscheme for debugging C/C++ using  Conque GDB

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -222,7 +222,8 @@ let g:solarized_termcolors=256
 "colorscheme solarized
 "colorscheme peaksea
 " Notice: theme molokayo will not show CtrlP even if it works very well.
-colorscheme raincode
+colorscheme corporation
+"colorscheme raincode
 "colorscheme molokayo
 "colorscheme molokai
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ VIM Plugins including
 *   vim-multiple-cursors
 *   vim-javacomplete2
 *   vim-python-pep8-indent
-*   Default Vim colorscheme is [**raincode**](https://github.com/xros/dotfiles/blob/master/.vim/colors/raincode.vim)
+*   Default Vim colorscheme is corporation. Also you can try this [**raincode**](https://github.com/xros/dotfiles/blob/master/.vim/colors/raincode.vim)
 *   and so on , just check it out. For VIM 7.3+
 
 ##### An Easter egg


### PR DESCRIPTION
This colorscheme works better than the raincode version 1.0 .
You can see step debugging vividly in vim console.