### PR TITLE
tmux v2.6 upgrade and versioning

### DIFF
--- a/.tmux.conf.old
+++ b/.tmux.conf.old
@@ -1,8 +1,7 @@
 # General tmux settings
-# Tmux settings after v2.6
-# Created by Alexander Liu
-# This is tested on Linux/OSX/BSD
-
+# This setting fits Tmux version before 2.6 not included
+# Tmux has changed its key binding syntax
+# For old systems. Created by Alexander Liu
 #set-option -g default-shell /bin/bash
 set -g default-terminal "screen-256color"
 # Automatically set window title
@@ -109,13 +108,9 @@ set -g status-right $tm_itunes' '$tm_date' '$tm_host
 
 # Vim bindings for Tmux
 set-window-option -g mode-keys vi
-bind-key -Tcopy-mode-vi 'v' send -X begin-selection 
-bind-key -Tcopy-mode-vi 'y' send -X copy-selection
-bind-key -Tcopy-mode-vi 'C-['  send -X cancel
-
-#bind-key -Tcopy-mode-vi 'v' begin-selection
-#bind-key -Tcopy-mode-vi 'y' copy-selection
-#bind-key -Tcopy-mode-vi 'C-[' cancel
+bind -t vi-copy 'v' begin-selection
+bind -t vi-copy 'y' copy-selection
+bind -t vi-copy 'C-[' cancel
 #unbind [
 #bind Escape copy-mode
 #unbind p

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Dot files
 ===
-    Dot files for Bash, Zsh, Vim, Elinks, Mutt, Gnupg, Python, Java, Rtorrent.
+    Dot files for Bash, Tmux, Zsh, Vim, Elinks, Mutt, Gnupg, Python, Java, Rtorrent.
     A C/C++/Java/Python/HTML IDE for Vim is built in.
-    Machine Learning Settings for TensorFlow 1.4 and Cuda 8.0
+    With Machine Learning Settings for TensorFlow 1.4 and Cuda 8.0
                           --- Created by Alexander Liu
 VIM Plugins including
 ---
@@ -172,6 +172,28 @@ Then select these 3 lines using Vim visual line keys <kbd>Shift</kbd><kbd>v</kbd
 
 
 * More info about this tool can be found at [emmet-vim](https://github.com/mattn/emmet-vim) and [more tutorials](https://raw.github.com/mattn/emmet-vim/master/TUTORIAL).
+
+#### Tmux operation in brief
+* In tmux, use key binding to move cursors for copying, pasting anything in terminal. (Add support for tmux version after 2.6 and before 2.6 on old servers/workstations)
+
+Enter copy and paste mode (Vi bindings)
+    <kbd>Ctrl</kbd><kbd>b</kbd><kbd>[</kbd>
+
+In copy/paste mode for cursor moving 
+
+| Direction | Key | 
+| down | <kbd>j</kbd> |
+| up | <kbd>k</kbd> |
+| left | <kbd>h</kbd> |
+| right | <kbd>l</kbd> |
+
+To select <kbd>v</kbd> 
+
+To copy/yank selection <kbd>y</kbd>
+
+To quit copy/paste mode, <kbd>q</kbd> or <kbd>Ctrl</kbd><kbd>[</kbd>
+
+To paste your selection, <kbd>Ctrl</kbd><kbd>b</kbd><kbd>]</kbd>
 
 #### CSV editor
 * For csv/dat file editing using csv.vim

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Then select these 3 lines using Vim visual line keys <kbd>Shift</kbd><kbd>v</kbd
 * More info about this tool can be found at [emmet-vim](https://github.com/mattn/emmet-vim) and [more tutorials](https://raw.github.com/mattn/emmet-vim/master/TUTORIAL).
 
 #### Tmux operation in brief
-* In tmux, use key binding to move cursors for copying, pasting anything in terminal. (Add support for tmux version after 2.6 and before 2.6 on old servers/workstations)
+* In tmux, use key bindings to move cursors for copying, pasting anything in terminal. (Add support for tmux version after 2.6 and before 2.6 on old servers/workstations)
 
 Enter copy and paste mode (Vi bindings)
     <kbd>Ctrl</kbd><kbd>b</kbd><kbd>[</kbd>
@@ -182,6 +182,7 @@ Enter copy and paste mode (Vi bindings)
 In copy/paste mode for cursor moving 
 
 | Direction | Key | 
+| -------:|: ----:|
 | down | <kbd>j</kbd> |
 | up | <kbd>k</kbd> |
 | left | <kbd>h</kbd> |

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Enter copy and paste mode (Vi bindings)
 In copy/paste mode for cursor moving 
 
 | Direction | Key | 
-| -------:|: ----:|
+| ------- | ----:|
 | down | <kbd>j</kbd> |
 | up | <kbd>k</kbd> |
 | left | <kbd>h</kbd> |
@@ -192,7 +192,7 @@ To select <kbd>v</kbd>
 
 To copy/yank selection <kbd>y</kbd>
 
-To quit copy/paste mode, <kbd>q</kbd> or <kbd>Ctrl</kbd><kbd>[</kbd>
+To quit copy/paste mode, <kbd>q</kbd>
 
 To paste your selection, <kbd>Ctrl</kbd><kbd>b</kbd><kbd>]</kbd>
 

--- a/cp_files.sh
+++ b/cp_files.sh
@@ -17,6 +17,7 @@ done
 
 # update Tmux settings since Tmux v2.6 upgraded its key binding syntax
 tmux_conf=".tmux.conf"
+echo "[+] NOTICE: for tmux versioning installation, you need install UNIX tool bc firstly."
 if [ -f $HOME/$tmux_conf ];then
    bak_file_loc=$HOME/$tmux_conf\.backup_$(date "+%Y%m%d%H%M%S")
    echo "[+] Backing up previous dot files settings: from "$tmux_conf" to $bak_file_loc"

--- a/cp_files.sh
+++ b/cp_files.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files=".bashrc .pythonstartup .tmux.conf .vimrc .zshrc .muttrc .gpg.rc .rtorrent.rc"
+files=".bashrc .pythonstartup .vimrc .zshrc .muttrc .gpg.rc .rtorrent.rc"
 echo "[+] Copying dotfiles... Need to back up previous ones before overwriting"
 for f in $files;do
     # copy those files to the user's $HOME folder
@@ -14,6 +14,34 @@ for f in $files;do
     fi
     #echo $f
 done
+
+# update Tmux settings since Tmux v2.6 upgraded its key binding syntax
+tmux_conf=".tmux.conf"
+if [ -f $HOME/$tmux_conf ];then
+   bak_file_loc=$HOME/$tmux_conf\.backup_$(date "+%Y%m%d%H%M%S")
+   echo "[+] Backing up previous dot files settings: from "$tmux_conf" to $bak_file_loc"
+   mv $HOME/$tmux_conf $bak_file_loc
+   tv=`tmux -V | awk '{print $2}'`
+   
+   threshold='2.6'
+   #echo $tv
+   
+   # $tv is a double digit, bash only compares integer
+   #if [ "$tv" -gt "2.6" ]; then
+   # version before 2.6
+   if [ `echo $tv\<$threshold | bc` -eq 1 ]; then 
+       echo "[+] Tmux verion < 2.6"
+       echo "[+] Updating tmux settings for version less than 2.6"
+       cp "$tmux_conf".old $HOME/.tmux.conf -f
+       #echo 'xiaoyu'
+   else
+   # version after 2.6
+       echo "[+] Tmux verion >= 2.6"
+       echo "[+] Updating tmux settings for version great equal than 2.6"
+       cp $tmux_conf  $HOME/
+       #echo 'dayu'
+   fi
+fi
 
 elinks_conf=$HOME/.elinks/elinks.conf
 if [ -f $elinks_conf ];then


### PR DESCRIPTION
This support old tmux and new tmux since version 2.6.
For old servers, PC, the old tmux bindings is still functioning very well!

This support MacOS 10.11 10.12 10.13 and home brew tmux. 
Yet it supports newer Linux destros.